### PR TITLE
Bigc 745 cart amount includes taxes we need

### DIFF
--- a/extension/lib/bigcommerce/Cart.js
+++ b/extension/lib/bigcommerce/Cart.js
@@ -79,6 +79,13 @@ class BigCommerceCart {
   }
 
   /**
+   * @returns {number}
+   */
+  get netCartAmount () {
+    return this.productsSubTotal - this.discountAmount
+  }
+
+  /**
    * @returns {boolean}
    */
   get taxIncluded () {

--- a/extension/lib/bigcommerce/Cart.js
+++ b/extension/lib/bigcommerce/Cart.js
@@ -75,13 +75,6 @@ class BigCommerceCart {
    * @returns {number}
    */
   get cartAmount () {
-    return this._cartAmount
-  }
-
-  /**
-   * @returns {number}
-   */
-  get netCartAmount () {
     return this.productsSubTotal - this.discountAmount
   }
 

--- a/extension/lib/shopgate/CartFactory.js
+++ b/extension/lib/shopgate/CartFactory.js
@@ -17,7 +17,7 @@ class ShopgateCartFactory {
     )
 
     cart.addTotal('discount', 'Discount', bigCommerceCart.discountAmount)
-    cart.addTotal('grandTotal', 'Total', bigCommerceCart.netCartAmount)
+    cart.addTotal('grandTotal', 'Total', bigCommerceCart.cartAmount)
 
     for (const lineItem of bigCommerceCart.lineItems.physical) {
       const listPrice = lineItem.listPrice !== 0 ? lineItem.listPrice : lineItem.salePrice

--- a/extension/lib/shopgate/CartFactory.js
+++ b/extension/lib/shopgate/CartFactory.js
@@ -17,7 +17,7 @@ class ShopgateCartFactory {
     )
 
     cart.addTotal('discount', 'Discount', bigCommerceCart.discountAmount)
-    cart.addTotal('grandTotal', 'Total', bigCommerceCart.cartAmount)
+    cart.addTotal('grandTotal', 'Total', bigCommerceCart.netCartAmount)
 
     for (const lineItem of bigCommerceCart.lineItems.physical) {
       const listPrice = lineItem.listPrice !== 0 ? lineItem.listPrice : lineItem.salePrice

--- a/extension/test/integration/bigcommerce/CartRepositoryTest.js
+++ b/extension/test/integration/bigcommerce/CartRepositoryTest.js
@@ -105,13 +105,7 @@ describe('BigCommerceCartRepository - integration', () => {
     shopgateCart.totals.should.containSubset([{
       _type: 'grandTotal',
       _label: 'Total',
-      /**
-       * BigCommerce currently returns $46.05 as cart_amount probably due to an API change between
-       * Fr 09th May 16:00 (MEZ) and Mo 14th May 14:36 (MEZ)
-       * This seems to be a bug and we already created a ticket for BigCommerce.
-       * Before that change BigCommerce returned $42.25
-       */
-      _amount: 46.05,
+      _amount: 42.25,
       _subTotals: []
     }])
 


### PR DESCRIPTION
It seems like the cartAmount returned by bigCommerce will include taxes should they apply but it gives no indication of what portion of the cart amount is tax. To ensure the grand total equals the sum of the items sale price minus discounts the get cartAmount method of the bigcommerce cart was changed to return a calculated total rather than the figure the bigcommerce api provides.